### PR TITLE
Ju cu sorted list

### DIFF
--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -107,7 +107,13 @@ const ItemsList = () => {
                   .includes(searchTerm.toLowerCase()),
               )
               .sort((a, b) =>
-                a.daysLeftForNextPurchase > b.daysLeftForNextPurchase ? 1 : -1,
+                a.daysLeftForNextPurchase > b.daysLeftForNextPurchase
+                  ? 1
+                  : a.daysLeftForNextPurchase === b.daysLeftForNextPurchase
+                  ? a.shoppingListItemName > b.shoppingListItemName
+                    ? 1
+                    : -1
+                  : -1,
               )
               .map((shoppingItemObject, index) => {
                 const shopIndex = shoppingList[0].items.indexOf(

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -73,7 +73,8 @@ const ItemsList = () => {
     history.push('/additem');
   };
 
-  const listHasAtLeastOneItem = shoppingList && shoppingList[0];
+  let listHasAtLeastOneItem = shoppingList && shoppingList[0];
+
   const listHasNoItems = shoppingList && !shoppingList.length;
 
   return (
@@ -103,6 +104,9 @@ const ItemsList = () => {
                 shoppingItemObject.shoppingListItemName
                   .toLowerCase()
                   .includes(searchTerm.toLowerCase()),
+              )
+              .sort((a, b) =>
+                a.daysLeftForNextPurchase > b.daysLeftForNextPurchase ? 1 : -1,
               )
               .map((shoppingItemObject, index) => {
                 const shopIndex = shoppingList[0].items.indexOf(

--- a/src/components/ItemsList.js
+++ b/src/components/ItemsList.js
@@ -7,6 +7,7 @@ import { useHistory } from 'react-router-dom';
 import calculateEstimate from '../lib/estimates';
 import '../styles/ItemsList.css';
 import SearchBar from './SearchBar';
+import { stylesFnx, describedState } from './sortingFunctions';
 
 const db = firebase.firestore().collection('shopping_list');
 
@@ -113,7 +114,14 @@ const ItemsList = () => {
                   shoppingItemObject,
                 );
                 return (
-                  <li key={shoppingItemObject.shoppingListItemName + index}>
+                  <li
+                    key={shoppingItemObject.shoppingListItemName + index}
+                    style={{
+                      backgroundColor: stylesFnx(
+                        shoppingItemObject.daysLeftForNextPurchase,
+                      ),
+                    }}
+                  >
                     <input
                       type="checkbox"
                       id={shoppingItemObject.shoppingListItemName}
@@ -122,7 +130,12 @@ const ItemsList = () => {
                         shoppingItemObject.lastPurchasedOn,
                       )}
                     />
-                    <label htmlFor={shoppingItemObject.shoppingListItemName}>
+                    <label
+                      htmlFor={shoppingItemObject.shoppingListItemName}
+                      aria-label={describedState(
+                        shoppingItemObject.daysLeftForNextPurchase,
+                      )}
+                    >
                       {shoppingItemObject.shoppingListItemName}
                     </label>
                   </li>

--- a/src/components/sortingFunctions.js
+++ b/src/components/sortingFunctions.js
@@ -3,17 +3,19 @@ export const stylesFnx = (days) => {
     return 'green';
   } else if (days > 7 && days <= 30) {
     return 'orange';
-  } else {
+  } else if (days > 30 && days <= 90) {
     return 'red';
+  } else {
+    return 'grey';
   }
 };
 
 export const describedState = (days) => {
   if (days <= 7) {
-    return 'this item needs to be bought soon (fewer than 7 days)';
+    return 'this item needs to be bought soon';
   } else if (days > 7 && days <= 30) {
-    return 'this item needs to be bought kind of soon (between 7 & 30 days)';
+    return 'this item needs to be bought kind of soon';
   } else {
-    return 'this item needs to be bought not soon (more than 30 days)';
+    return 'this item needs to be bought not soon';
   }
 };

--- a/src/components/sortingFunctions.js
+++ b/src/components/sortingFunctions.js
@@ -1,0 +1,19 @@
+export const stylesFnx = (days) => {
+  if (days <= 7) {
+    return 'green';
+  } else if (days > 7 && days <= 30) {
+    return 'orange';
+  } else {
+    return 'red';
+  }
+};
+
+export const describedState = (days) => {
+  if (days <= 7) {
+    return 'this item needs to be bought soon (fewer than 7 days)';
+  } else if (days > 7 && days <= 30) {
+    return 'this item needs to be bought kind of soon (between 7 & 30 days)';
+  } else {
+    return 'this item needs to be bought not soon (more than 30 days)';
+  }
+};


### PR DESCRIPTION
## Description

This PR adds these two functionalities  

##sort shopping list

this functionality sorts a users shopping list items in order of how soon they are likely to buy the items so it is clear what they need to buy next.

##show list  as visually distinct

this functionality adds  background color to shopping  list Items in the list according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive

## Related Issue

closes #12 

## Acceptance Criteria

[X] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive

[X] Items should be sorted by the estimated number of days until next purchase

[X] Items with the same number of estimated days until next purchase should be sorted alphabetically

[X] Items in the different states should be described distinctly when read by a screen reader


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

![Screenshot (103)](https://user-images.githubusercontent.com/57858821/107516223-ed778e80-6b60-11eb-9bfd-5194feb973ee.png)


### After

![Screenshot (102)](https://user-images.githubusercontent.com/57858821/107516239-f36d6f80-6b60-11eb-89e4-42fedd1d42b0.png)


## Testing Steps / QA Criteria

* From your terminal, pull down this branch with "git pull origin ju-cu-sorted-list" and check that branch out with "git checkout ju-cu-sorted-list"
* start the server with "npm start"
* Create a new list and add items to the list to notice that the shopping list is sorted according number of days left for each item to be purchased, and the background colors grouping the items into how soon they need to be purchased. Green color for soon (less than or equal to 7days), Orange color for kind of soon (7-30 days) and red color for not soon(above 30 days)
* to see the functionalities already in action, join an existing list with this token "franz mere llll"

